### PR TITLE
Update ZoneMusic to add Play and StopMusic methods

### DIFF
--- a/Scripts/SLZ.Marrow/SLZ.Marrow.Zones/ZoneMusic.cs
+++ b/Scripts/SLZ.Marrow/SLZ.Marrow.Zones/ZoneMusic.cs
@@ -45,5 +45,13 @@ namespace SLZ.Marrow.Zones
         public DataCardReference<MonoDisc> introTrack;
         [HideInInspector]
         public static bool zoneMusicPasted = false;
+
+        public void Play()
+        { 
+        }
+
+        public void StopMusic(float fadeTime)
+        {
+        }
     }
 }


### PR DESCRIPTION
These are methods in game, but were hollowed from SLZ's sdk and never made it back over to the Extended SDK. Tested and work when called from UltEvents.