### PR TITLE
Add missing fields to CircuitSocket and ButtonController

### DIFF
--- a/Scripts/SLZ.Marrow/SLZ.Marrow.Circuits/ButtonController.cs
+++ b/Scripts/SLZ.Marrow/SLZ.Marrow.Circuits/ButtonController.cs
@@ -24,6 +24,17 @@ namespace SLZ.Marrow.Circuits
         [SerializeField]
         protected AudioClip[] _depressClips;
 
+        public ButtonMode buttonMode
+        {
+            get
+            {
+                return _buttonMode;
+            }
+            set
+            {
+            }
+        }
+
         public enum ButtonMode
         {
             ClickUp,

--- a/Scripts/SLZ.Marrow/SLZ.Marrow.Circuits/ButtonController.cs
+++ b/Scripts/SLZ.Marrow/SLZ.Marrow.Circuits/ButtonController.cs
@@ -7,6 +7,23 @@ namespace SLZ.Marrow.Circuits
     {
         [SerializeField]
         private ButtonMode _buttonMode = ButtonMode.ClickUp;
+
+        private const float downThreshold = 0.9f;
+
+        private const float upThreshold = 0.1f;
+
+        private bool _charged;
+        
+        private bool _toggleCharged;
+
+        [Tooltip("Clip(s) to be played on button press")]
+        [SerializeField]
+        protected AudioClip[] _pressClips;
+
+        [Tooltip("Clip(s) to be played on button unpress")]
+        [SerializeField]
+        protected AudioClip[] _depressClips;
+
         public enum ButtonMode
         {
             ClickUp,

--- a/Scripts/SLZ.Marrow/SLZ.Marrow.Circuits/CircuitSocket.cs
+++ b/Scripts/SLZ.Marrow/SLZ.Marrow.Circuits/CircuitSocket.cs
@@ -24,5 +24,11 @@ namespace SLZ.Marrow.Circuits
             {
             }
         }
+        
+        protected virtual void Reset()
+        {
+            TryGetComponent(out _servo);
+            TryGetComponent(out _rb);
+        }
     }
 }

--- a/Scripts/SLZ.Marrow/SLZ.Marrow.Circuits/CircuitSocket.cs
+++ b/Scripts/SLZ.Marrow/SLZ.Marrow.Circuits/CircuitSocket.cs
@@ -1,8 +1,28 @@
 using UnityEngine;
+using SLZ.Marrow;
 
 namespace SLZ.Marrow.Circuits
 {
     public class CircuitSocket : Circuit
     {
+        [SerializeField]
+        private Circuit _input;
+
+        [SerializeField]
+        protected Servo _servo;
+
+        [SerializeField]
+        protected Rigidbody _rb;
+
+        public Circuit input
+        {
+            get
+            {
+                return null;
+            }
+            set
+            {
+            }
+        }
     }
 }


### PR DESCRIPTION
This will allow modders to create their own Buttons, Levers, and Sliders by providing the Circuit Input, as well as the necessary Servo and Rigidbody fields.